### PR TITLE
Bump build for fixed numpy pin

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -5,25 +5,29 @@
 jobs:
 - job: linux
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-latest
   strategy:
     matrix:
       linux_64_numpy1.17python3.6.____cpython:
         CONFIG: linux_64_numpy1.17python3.6.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+        SHORT_CONFIG_NAME: linux_64_numpy1.17python3.6.____cpython
       linux_64_numpy1.17python3.7.____cpython:
         CONFIG: linux_64_numpy1.17python3.7.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+        SHORT_CONFIG_NAME: linux_64_numpy1.17python3.7.____cpython
       linux_64_numpy1.17python3.8.____cpython:
         CONFIG: linux_64_numpy1.17python3.8.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+        SHORT_CONFIG_NAME: linux_64_numpy1.17python3.8.____cpython
       linux_64_numpy1.19python3.9.____cpython:
         CONFIG: linux_64_numpy1.19python3.9.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+        SHORT_CONFIG_NAME: linux_64_numpy1.19python3.9.____cpython
   timeoutInMinutes: 360
 
   steps:
@@ -51,8 +55,7 @@ jobs:
       FEEDSTOCK_TOKEN: $(FEEDSTOCK_TOKEN)
       STAGING_BINSTAR_TOKEN: $(STAGING_BINSTAR_TOKEN)
   - script: |
-        full_artifact_name="conda_artifacts_$(build.BuildId)_$(CONFIG)"
-        artifact_name=`echo "$full_artifact_name" | head -c 80`
+        artifact_name="conda_artifacts_$(build.BuildId)_$(SHORT_CONFIG_NAME)"
         echo "##vso[task.setVariable variable=ARTIFACT_NAME]$artifact_name"
         if [ -d build_artifacts ]; then
           echo "##vso[task.setVariable variable=CONDA_BLD_DIR_EXISTS]true"

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -11,21 +11,27 @@ jobs:
       osx_64_numpy1.17python3.6.____cpython:
         CONFIG: osx_64_numpy1.17python3.6.____cpython
         UPLOAD_PACKAGES: 'True'
+        SHORT_CONFIG_NAME: osx_64_numpy1.17python3.6.____cpython
       osx_64_numpy1.17python3.7.____cpython:
         CONFIG: osx_64_numpy1.17python3.7.____cpython
         UPLOAD_PACKAGES: 'True'
+        SHORT_CONFIG_NAME: osx_64_numpy1.17python3.7.____cpython
       osx_64_numpy1.17python3.8.____cpython:
         CONFIG: osx_64_numpy1.17python3.8.____cpython
         UPLOAD_PACKAGES: 'True'
+        SHORT_CONFIG_NAME: osx_64_numpy1.17python3.8.____cpython
       osx_64_numpy1.19python3.9.____cpython:
         CONFIG: osx_64_numpy1.19python3.9.____cpython
         UPLOAD_PACKAGES: 'True'
+        SHORT_CONFIG_NAME: osx_64_numpy1.19python3.9.____cpython
       osx_arm64_python3.8.____cpython:
         CONFIG: osx_arm64_python3.8.____cpython
         UPLOAD_PACKAGES: 'True'
+        SHORT_CONFIG_NAME: osx_arm64_python3.8.____cpython
       osx_arm64_python3.9.____cpython:
         CONFIG: osx_arm64_python3.9.____cpython
         UPLOAD_PACKAGES: 'True'
+        SHORT_CONFIG_NAME: osx_arm64_python3.9.____cpython
   timeoutInMinutes: 360
 
   steps:
@@ -42,8 +48,7 @@ jobs:
       FEEDSTOCK_TOKEN: $(FEEDSTOCK_TOKEN)
       STAGING_BINSTAR_TOKEN: $(STAGING_BINSTAR_TOKEN)
   - script: |
-        full_artifact_name="conda_artifacts_$(build.BuildId)_$(CONFIG)"
-        artifact_name=`echo "$full_artifact_name" | head -c 80`
+        artifact_name="conda_artifacts_$(build.BuildId)_$(SHORT_CONFIG_NAME)"
         echo "##vso[task.setVariable variable=ARTIFACT_NAME]$artifact_name"
         if [ -d /Users/runner/miniforge3/conda-bld/ ]; then
           echo "##vso[task.setVariable variable=CONDA_BLD_DIR_EXISTS]true"

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -11,15 +11,19 @@ jobs:
       win_64_numpy1.17python3.6.____cpython:
         CONFIG: win_64_numpy1.17python3.6.____cpython
         UPLOAD_PACKAGES: 'True'
+        SHORT_CONFIG_NAME: win_64_numpy1.17python3.6.____cpython
       win_64_numpy1.17python3.7.____cpython:
         CONFIG: win_64_numpy1.17python3.7.____cpython
         UPLOAD_PACKAGES: 'True'
+        SHORT_CONFIG_NAME: win_64_numpy1.17python3.7.____cpython
       win_64_numpy1.17python3.8.____cpython:
         CONFIG: win_64_numpy1.17python3.8.____cpython
         UPLOAD_PACKAGES: 'True'
+        SHORT_CONFIG_NAME: win_64_numpy1.17python3.8.____cpython
       win_64_numpy1.19python3.9.____cpython:
         CONFIG: win_64_numpy1.19python3.9.____cpython
         UPLOAD_PACKAGES: 'True'
+        SHORT_CONFIG_NAME: win_64_numpy1.19python3.9.____cpython
   timeoutInMinutes: 360
   variables:
     CONDA_BLD_PATH: D:\\bld\\
@@ -101,8 +105,7 @@ jobs:
         PYTHONUNBUFFERED: 1
       condition: not(contains(variables['CONFIG'], 'vs2008'))
     - script: |
-        set full_artifact_name=conda_artifacts_$(build.BuildID)_$(CONFIG)
-        set artifact_name=%full_artifact_name:~0,80%
+        set artifact_name=conda_artifacts_$(build.BuildID)_$(SHORT_CONFIG_NAME)
         echo ##vso[task.setVariable variable=ARTIFACT_NAME]%artifact_name%
         if exist $(CONDA_BLD_PATH)\\ (
           echo ##vso[task.setVariable variable=CONDA_BLD_DIR_EXISTS]true

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - 0002-Single-patch-to-v0.2.3-for-GR-3.9-compatibility.patch
 
 build:
-  number: 6
+  number: 7
   run_exports:
     - {{ pin_subpackage('gnuradio-osmosdr', max_pin='x.x') }}
 


### PR DESCRIPTION
The last PR added the numpy pin (correctly), but the build number wasn't bumped and so now users may or may not get the version that works with numpy < 1.20.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
